### PR TITLE
Dup field alias

### DIFF
--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -72,7 +72,7 @@ class ArSerializer::Field
 
   def validate_attributes(attributes)
     return unless @only || @except
-    keys = attributes.keys.map(&:to_s) - ['*']
+    keys = attributes.map(&:first).map(&:to_s) - ['*']
     return unless (@only && (keys - @only).present?) || (@except && (keys & @except).present?)
     invalid_keys = [*(@only && keys - @only), *(@except && keys & @except)].uniq
     raise ArSerializer::InvalidQuery, "unpermitted attribute: #{invalid_keys}"

--- a/test/ar_serializer_test.rb
+++ b/test/ar_serializer_test.rb
@@ -120,6 +120,16 @@ class ArSerializerTest < Minitest::Test
     assert_equal expected, ArSerializer.serialize(post, query)
   end
 
+  def test_dup_alias
+    users = User.all
+    expected = users.map { |u| { id1: u.id, id2: u.id, name1: u.name, name2: u.name } }
+    query = [
+      { id: { as: :id1 } }, { id: { as: :id2 } },
+      { name: { as: :name1 } }, { name: { as: :name2 } }
+    ]
+    assert_equal expected, ArSerializer.serialize(users, query)
+  end
+
   def test_query_count
     user = Star.first.comment.post.user
     query = {


### PR DESCRIPTION
```ruby
ArSerializer.serialize User.find(4), [{ id: { as: :id1 } }, { id: { as: :id2 } }]
# => { id1: 4, id2: 4 }
```
#13 のqueryのフォーマット変えるための準備