### PR TITLE
always accept primary key ordering

### DIFF
--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -194,7 +194,7 @@ class ArSerializer::Field
     end
     info = klass._serializer_field_info(key)
     key = info&.order_column || key.to_s.underscore
-    raise ArSerializer::InvalidQuery, "unpermitted order key: #{key}" unless klass.has_attribute?(key) && info
+    raise ArSerializer::InvalidQuery, "unpermitted order key: #{key}" unless klass.primary_key == key.to_s || (klass.has_attribute?(key) && info)
     raise ArSerializer::InvalidQuery, "invalid order mode: #{mode.inspect}" unless [:asc, :desc, 'asc', 'desc'].include? mode
     [key.to_sym, mode.to_sym]
   end


### PR DESCRIPTION
#16 直す
serializer_field :idがないと動かなかった。
デフォルトでprimary_key順になってるので、primary_keyでのorderを禁止する理由がない。
なのでprimary_keyだけは例外でfield定義してなくてもorder_keyとして許可
(デフォルトの並び順を変えれた方がいい？いや別にいいか、必要ならqueryで指定したらいいはず...)