### PR TITLE
閲覧権限がないデータを返さない仕組み

### DIFF
--- a/lib/ar_serializer.rb
+++ b/lib/ar_serializer.rb
@@ -25,11 +25,16 @@ module ArSerializer::Serializable
       superclass._serializer_field_info name if superclass < ArSerializer::Serializable
     end
 
-    def _serializer_field_keys
+    def _serializer_field_keys(public_only = true)
       keys = ArSerializer::Serializer.current_namespaces.map do |ns|
-        _serializer_namespace(ns).keys
+        if public_only
+          fields = _serializer_namespace(ns)
+          fields.keys.reject { |key| fields[key].private? }
+        else
+          _serializer_namespace(ns).keys
+        end
       end.inject(:|)
-      keys |= superclass._serializer_field_keys if superclass < ArSerializer::Serializable
+      keys |= superclass._serializer_field_keys(public_only) if superclass < ArSerializer::Serializable
       keys
     end
 
@@ -58,11 +63,11 @@ module ArSerializer::Serializable
     end
 
     def serializer_permission(**args, &data_block)
-      serializer_field(:permission, **args, &data_block)
+      serializer_field(:permission, **args, private: true, &data_block)
     end
 
     def serializer_defaults(**args, &block)
-      serializer_field(:defaults, **args, &block)
+      serializer_field(:defaults, **args, private: true, &block)
     end
   end
 end

--- a/lib/ar_serializer.rb
+++ b/lib/ar_serializer.rb
@@ -57,14 +57,18 @@ module ArSerializer::Serializable
       _custom_preloaders[name] = block
     end
 
+    def serializer_permission(**args, &data_block)
+      serializer_field(:permission, **args, &data_block)
+    end
+
     def serializer_defaults(**args, &block)
-      serializer_field :defaults, **args, &block
+      serializer_field(:defaults, **args, &block)
     end
   end
 end
 
 ActiveRecord::Base.include ArSerializer::Serializable
-ActiveRecord::Relation.include ArSerializer::ArrayLikeCompositeValue
+ActiveRecord::Relation.include ArSerializer::ArrayLikeSerializable
 
 require 'ar_serializer/graphql'
 require 'ar_serializer/type_script'

--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -2,8 +2,8 @@ require 'ar_serializer/error'
 require 'top_n_loader'
 
 class ArSerializer::Field
-  attr_reader :includes, :preloaders, :data_block, :only, :except, :child_permission, :order_column
-  def initialize klass, name, includes: nil, preloaders: [], data_block:, only: nil, except: nil, private: false, child_permission: nil, order_column: nil, orderable: nil, type: nil, params_type: nil
+  attr_reader :includes, :preloaders, :data_block, :only, :except, :scoped_access, :order_column
+  def initialize klass, name, includes: nil, preloaders: [], data_block:, only: nil, except: nil, private: false, scoped_access: nil, order_column: nil, orderable: nil, type: nil, params_type: nil
     @klass = klass
     @name = name
     @includes = includes
@@ -11,7 +11,7 @@ class ArSerializer::Field
     @only = only && [*only].map(&:to_s)
     @except = except && [*except].map(&:to_s)
     @private = private
-    @child_permission = child_permission.nil? ? true : child_permission
+    @scoped_access = scoped_access.nil? ? true : scoped_access
     @data_block = data_block
     @order_column = order_column
     @orderable = orderable
@@ -133,10 +133,10 @@ class ArSerializer::Field
     }[attr_type.type]
   end
 
-  def self.create(klass, name, type: nil, params_type: nil, count_of: nil, includes: nil, preload: nil, only: nil, except: nil, private: nil, child_permission: nil, order_column: nil, orderable: nil, &data_block)
+  def self.create(klass, name, type: nil, params_type: nil, count_of: nil, includes: nil, preload: nil, only: nil, except: nil, private: nil, scoped_access: nil, order_column: nil, orderable: nil, &data_block)
     name = name.to_s
     if count_of
-      if includes || preload || data_block || only || except || order_column || orderable || child_permission != nil
+      if includes || preload || data_block || only || except || order_column || orderable || scoped_access != nil
         raise ArgumentError, 'wrong options for count_of field'
       end
       return count_field klass, name, count_of
@@ -150,7 +150,7 @@ class ArSerializer::Field
       else
         type ||= -> { association.klass }
       end
-      return association_field klass, name, only: only, except: except, child_permission: child_permission, type: type, collection: association.collection? if !includes && !preload && !data_block && !params_type
+      return association_field klass, name, only: only, except: except, scoped_access: scoped_access, type: type, collection: association.collection? if !includes && !preload && !data_block && !params_type
     end
     type ||= lambda do
       if klass.respond_to? :column_for_attribute
@@ -161,10 +161,10 @@ class ArSerializer::Field
         :any
       end
     end
-    custom_field klass, name, includes: includes, preload: preload, only: only, except: except, private: private, child_permission: child_permission, order_column: order_column, orderable: orderable, type: type, params_type: params_type, &data_block
+    custom_field klass, name, includes: includes, preload: preload, only: only, except: except, private: private, scoped_access: scoped_access, order_column: order_column, orderable: orderable, type: type, params_type: params_type, &data_block
   end
 
-  def self.custom_field(klass, name, includes:, preload:, only:, except:, private:, child_permission: nil, order_column:, orderable:, type:, params_type:, &data_block)
+  def self.custom_field(klass, name, includes:, preload:, only:, except:, private:, scoped_access:, order_column:, orderable:, type:, params_type:, &data_block)
     underscore_name = name.underscore
     if preload
       preloaders = Array(preload).map do |preloader|
@@ -183,7 +183,7 @@ class ArSerializer::Field
     new(
       klass,
       name,
-      includes: includes, preloaders: preloaders, only: only, except: except, private: private, child_permission: child_permission, order_column: order_column, orderable: orderable, type: type, params_type: params_type,
+      includes: includes, preloaders: preloaders, only: only, except: except, private: private, scoped_access: scoped_access, order_column: order_column, orderable: orderable, type: type, params_type: params_type,
       data_block: data_block || ->(_context, **_params) { __send__ underscore_name }
     )
   end
@@ -208,7 +208,7 @@ class ArSerializer::Field
     [order_key, mode]
   end
 
-  def self.association_field(klass, name, only:, except:, child_permission: nil, type:, collection:)
+  def self.association_field(klass, name, only:, except:, scoped_access: nil, type:, collection:)
     underscore_name = name.underscore
     only = [*only] if only
     except = [*except] if except
@@ -236,7 +236,7 @@ class ArSerializer::Field
     data_block = lambda do |preloaded, _context, **_params|
       preloaded ? preloaded[id] || [] : __send__(underscore_name)
     end
-    new klass, name, preloaders: [preloader], data_block: data_block, only: only, except: except, child_permission: child_permission, type: type, params_type: params_type, orderable: false
+    new klass, name, preloaders: [preloader], data_block: data_block, only: only, except: except, scoped_access: scoped_access, type: type, params_type: params_type, orderable: false
   end
 
   def self.preload_association(klass, models, name, limit: nil, order: nil, only: nil, except: nil)

--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -238,7 +238,7 @@ class ArSerializer::Field
     order_key, order_mode = parse_order klass.reflect_on_association(name).klass, order, only: only, except: except
     return TopNLoader.load_associations klass, models.map(&:id), name, limit: limit, order: { order_key => order_mode } if limit
     ActiveRecord::Associations::Preloader.new.preload models, name
-    return if order.nil?
+    return models.map { |m| [m.id, m.send(name)] }.to_h if order.nil?
     models.map do |model|
       records_nonnils, records_nils = model.__send__(name).partition(&order_key)
       records = records_nils.sort_by(&:id) + records_nonnils.sort_by { |r| [r[order_key], r.id] }

--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -247,7 +247,7 @@ class ArSerializer::Field
     order_key, order_mode = parse_order klass.reflect_on_association(name).klass, order, only: only, except: except
     return TopNLoader.load_associations klass, models.map(&:id), name, limit: limit, order: { order_key => order_mode } if limit
     ActiveRecord::Associations::Preloader.new.preload models, name
-    return models.map { |m| [m.id, m.send(name)] }.to_h if order.nil?
+    return models.map { |m| [m.id, m.__send__(name)] }.to_h if order.nil?
     models.map do |model|
       records_nonnils, records_nils = model.__send__(name).partition(&order_key)
       records = records_nils.sort_by(&:id) + records_nonnils.sort_by { |r| [r[order_key], r.id] }

--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -228,13 +228,16 @@ class ArSerializer::Field
           order?: orderable_keys.map { |key| { key => modes } } +  modes
         }
       }
+      data_block = lambda do |preloaded, _context, **_params|
+        preloaded ? preloaded[id] || [] : __send__(underscore_name)
+      end
     else
       preloader = lambda do |models, _context, **_params|
         preload_association klass, models, underscore_name
       end
-    end
-    data_block = lambda do |preloaded, _context, **_params|
-      preloaded ? preloaded[id] || [] : __send__(underscore_name)
+      data_block = lambda do |preloaded, _context, **_params|
+        preloaded ? preloaded[id] : __send__(underscore_name)
+      end
     end
     new klass, name, preloaders: [preloader], data_block: data_block, only: only, except: except, scoped_access: scoped_access, type: type, params_type: params_type, orderable: false
   end

--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -2,14 +2,15 @@ require 'ar_serializer/error'
 require 'top_n_loader'
 
 class ArSerializer::Field
-  attr_reader :includes, :preloaders, :data_block, :only, :except, :order_column
-  def initialize klass, name, includes: nil, preloaders: [], data_block:, only: nil, except: nil, order_column: nil, orderable: nil, type: nil, params_type: nil
+  attr_reader :includes, :preloaders, :data_block, :only, :except, :child_permission, :order_column
+  def initialize klass, name, includes: nil, preloaders: [], data_block:, only: nil, except: nil, child_permission: nil, order_column: nil, orderable: nil, type: nil, params_type: nil
     @klass = klass
     @name = name
     @includes = includes
     @preloaders = preloaders
     @only = only && [*only].map(&:to_s)
     @except = except && [*except].map(&:to_s)
+    @child_permission = child_permission.nil? ? true : child_permission
     @data_block = data_block
     @order_column = order_column
     @orderable = orderable
@@ -127,10 +128,10 @@ class ArSerializer::Field
     }[attr_type.type]
   end
 
-  def self.create(klass, name, type: nil, params_type: nil, count_of: nil, includes: nil, preload: nil, only: nil, except: nil, order_column: nil, orderable: nil, &data_block)
+  def self.create(klass, name, type: nil, params_type: nil, count_of: nil, includes: nil, preload: nil, only: nil, except: nil, child_permission: nil, order_column: nil, orderable: nil, &data_block)
     name = name.to_s
     if count_of
-      if includes || preload || data_block || only || except || order_column || orderable
+      if includes || preload || data_block || only || except || order_column || orderable || child_permission != nil
         raise ArgumentError, 'wrong options for count_of field'
       end
       return count_field klass, name, count_of
@@ -144,7 +145,7 @@ class ArSerializer::Field
       else
         type ||= -> { association.klass }
       end
-      return association_field klass, name, only: only, except: except, type: type, collection: association.collection? if !includes && !preload && !data_block && !params_type
+      return association_field klass, name, only: only, except: except, child_permission: child_permission, type: type, collection: association.collection? if !includes && !preload && !data_block && !params_type
     end
     type ||= lambda do
       if klass.respond_to? :column_for_attribute
@@ -155,10 +156,10 @@ class ArSerializer::Field
         :any
       end
     end
-    custom_field klass, name, includes: includes, preload: preload, only: only, except: except, order_column: order_column, orderable: orderable, type: type, params_type: params_type, &data_block
+    custom_field klass, name, includes: includes, preload: preload, only: only, except: except, child_permission: child_permission, order_column: order_column, orderable: orderable, type: type, params_type: params_type, &data_block
   end
 
-  def self.custom_field(klass, name, includes:, preload:, only:, except:, order_column:, orderable:, type:, params_type:, &data_block)
+  def self.custom_field(klass, name, includes:, preload:, only:, except:, child_permission: nil, order_column:, orderable:, type:, params_type:, &data_block)
     underscore_name = name.underscore
     if preload
       preloaders = Array(preload).map do |preloader|
@@ -177,7 +178,7 @@ class ArSerializer::Field
     new(
       klass,
       name,
-      includes: includes, preloaders: preloaders, only: only, except: except, order_column: order_column, orderable: orderable, type: type, params_type: params_type,
+      includes: includes, preloaders: preloaders, only: only, except: except, child_permission: child_permission, order_column: order_column, orderable: orderable, type: type, params_type: params_type,
       data_block: data_block || ->(_context, **_params) { __send__ underscore_name }
     )
   end
@@ -202,7 +203,7 @@ class ArSerializer::Field
     [order_key, mode]
   end
 
-  def self.association_field(klass, name, only:, except:, type:, collection:)
+  def self.association_field(klass, name, only:, except:, child_permission: nil, type:, collection:)
     underscore_name = name.underscore
     only = [*only] if only
     except = [*except] if except
@@ -230,7 +231,7 @@ class ArSerializer::Field
     data_block = lambda do |preloaded, _context, **_params|
       preloaded ? preloaded[id] || [] : __send__(underscore_name)
     end
-    new klass, name, preloaders: [preloader], data_block: data_block, only: only, except: except, type: type, params_type: params_type, orderable: false
+    new klass, name, preloaders: [preloader], data_block: data_block, only: only, except: except, child_permission: child_permission, type: type, params_type: params_type, orderable: false
   end
 
   def self.preload_association(klass, models, name, limit: nil, order: nil, only: nil, except: nil)

--- a/lib/ar_serializer/serializer.rb
+++ b/lib/ar_serializer/serializer.rb
@@ -48,7 +48,7 @@ module ArSerializer::Serializer
       next unless klass.respond_to? :_serializer_field_info
       models.uniq!
       if attributes.any? { |k, _| k == :* }
-        all_keys = klass._serializer_field_keys.map(&:to_sym) - [:defaults]
+        all_keys = klass._serializer_field_keys.map(&:to_sym)
         all_keys &= only.map(&:to_sym) if only
         all_keys -= except.map(&:to_sym) if except
         attributes = all_keys.map { |k| [k, {}] } + attributes.reject { |k, _| k == :* }
@@ -56,7 +56,10 @@ module ArSerializer::Serializer
       attributes.each do |name, sub_args|
         field_name = sub_args[:field_name] || name
         field = klass._serializer_field_info field_name
-        raise ArSerializer::InvalidQuery, "No serializer field `#{field_name}`#{" namespaces: #{current_namespaces.compact}" if current_namespaces.any?} for #{klass}" unless field
+        if field.nil? || field.private?
+          message = "No serializer field `#{field_name}`#{" namespaces: #{current_namespaces.compact}" if current_namespaces.any?} for #{klass}"
+          raise ArSerializer::InvalidQuery, message
+        end
         ActiveRecord::Associations::Preloader.new.preload models, field.includes if field.includes.present?
       end
 

--- a/lib/ar_serializer/serializer.rb
+++ b/lib/ar_serializer/serializer.rb
@@ -162,7 +162,7 @@ module ArSerializer::Serializer
               end
             end
           when :custom
-            data[column_name] = res.ar_custom_serializable_data result
+            data[column_name] = res.ar_custom_serializable_data result || {}
           when :data
             data[column_name] = res
           end

--- a/lib/ar_serializer/serializer.rb
+++ b/lib/ar_serializer/serializer.rb
@@ -142,7 +142,7 @@ module ArSerializer::Serializer
             context,
             only: info.only,
             except: info.except,
-            permission: info.child_permission
+            permission: info.scoped_access
           )
         end
 

--- a/lib/ar_serializer/serializer.rb
+++ b/lib/ar_serializer/serializer.rb
@@ -116,7 +116,6 @@ module ArSerializer::Serializer
         sub_results = {}
         sub_models = []
         models.each do |model|
-          value, output = :fixme
           child = model.instance_exec(*preloadeds, context, **(params || {}), &data_block)
           if child.is_a?(ArSerializer::ArrayLikeSerializable) || (child.is_a?(Array) && child.any? { |el| el.is_a? ArSerializer::Serializable })
             sub_results[model] = [:multiple, child]

--- a/lib/ar_serializer/serializer.rb
+++ b/lib/ar_serializer/serializer.rb
@@ -80,7 +80,7 @@ module ArSerializer::Serializer
       permission = klass._serializer_field_info :permission
       if permission
         preloadeds = permission.preloaders.map do |p|
-          preloader_values[[p]] ||= preload.call p, nil
+          preloader_values[[p, nil]] ||= preload.call p, nil
         end
         models = models.select do |model|
           model.instance_exec(*preloadeds, context, {}, &permission.data_block)
@@ -90,7 +90,7 @@ module ArSerializer::Serializer
       defaults = klass._serializer_field_info :defaults
       if defaults
         defaults.preloaders.each do |p|
-          preloader_values[[p]] ||= preload.call p, nil
+          preloader_values[[p, nil]] ||= preload.call p, nil
         end
       end
 

--- a/test/ar_serializer_test.rb
+++ b/test/ar_serializer_test.rb
@@ -50,6 +50,13 @@ class ArSerializerTest < Minitest::Test
     assert_equal expected, ArSerializer.serialize(user, [:name, posts: :title])
   end
 
+  def test_child_nil
+    post = Post.first
+    post.user = nil
+    expected = { user: nil }
+    assert_equal expected, ArSerializer.serialize(post, :user)
+  end
+
   def test_context
     star = Star.first
     user = star.user
@@ -281,7 +288,6 @@ class ArSerializerTest < Minitest::Test
       ArSerializer.serialize user_class.all, { postsOnlyTitle: [:title, params: { order: { body: :asc } }] }
     end
   end
-
 
   def test_subclasses
     klass = Class.new User do

--- a/test/ar_serializer_test.rb
+++ b/test/ar_serializer_test.rb
@@ -402,6 +402,7 @@ class ArSerializerTest < Minitest::Test
     assert_equal ArSerializer.serialize(obj, :id), { id: 1 }
     assert_equal ArSerializer.serialize(obj, :id, use: :foo), { id: 1, bar: 2, baz: 3 }
     assert_equal ArSerializer.serialize(obj, :*, use: :foo), { id: 1, name: 'name', bar: 2, baz: 3 }
+    assert_raises(ArSerializer::InvalidQuery) { ArSerializer.serialize obj, :defaults }
   end
 
   def test_has_one_permission

--- a/test/ar_serializer_test.rb
+++ b/test/ar_serializer_test.rb
@@ -438,9 +438,9 @@ class ArSerializerTest < Minitest::Test
     p1_count = 0
     p2_count = 0
     p3_count = 0
-    preloader1 = ->(users) { $a=users;p1_count += 1; [:p1, users.size] }
-    preloader2 = ->(users) { $b=users;p2_count += 1; [:p2, users.size] }
-    preloader3 = ->(users) { $c=users;p3_count += 1; [:p3, users.size] }
+    preloader1 = ->(users) { p1_count += 1; [:p1, users.size] }
+    preloader2 = ->(users) { p2_count += 1; [:p2, users.size] }
+    preloader3 = ->(users) { p3_count += 1; [:p3, users.size] }
     commented_users_count = Comment.distinct.count(:user_id)
     User.serializer_permission namespace: ns, preload: [preloader1, preloader2] do |p1, p2|
       raise unless p1 == [:p1, commented_users_count]

--- a/test/model.rb
+++ b/test/model.rb
@@ -20,7 +20,7 @@ class User < ActiveRecord::Base
       ]
     end
   ) do |(lists, totals)|
-    models = lists ? list[id] : posts
+    models = lists[id]
     total = totals[id] || 0
     ArSerializer::CustomSerializable.new models do |result|
       { total: total, list: models.map(&result) }


### PR DESCRIPTION
permission fieldを定義

sub field中のpermissionを調べ、権限のないものを弾く

```ruby
User.serializer_field :posts
Post.serializer_permission { id.odd? }
ArSerializer.serialize User.all, posts: :id # 奇数idしか取れないように
```

ついでに重複が多い場合(例えばcomments[i].userが重複)にだいぶ速くなる