### PR TITLE
remove "define_preloader"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ end
 
 # preloader
 class Foo < ActiveRecord::Base
-  define_preloader :bar_count_loader do |models|
+  bar_count_loader = ->(models) do
     Bar.where(foo_id: models.map(&:id)).group(:foo_id).count
   end
-  serializer_field :bar_count, preload: preloader_name_or_proc do |preloaded|
+  serializer_field :bar_count, preload: bar_count_loader do |preloaded|
     preloaded[id] || 0
   end
   # data_blockが `do |preloaded| preloaded[id] end` の場合は省略可能

--- a/lib/ar_serializer.rb
+++ b/lib/ar_serializer.rb
@@ -54,14 +54,6 @@ module ArSerializer::Serializable
       end
     end
 
-    def _custom_preloaders
-      @_custom_preloaders ||= {}
-    end
-
-    def define_preloader(name, &block)
-      _custom_preloaders[name] = block
-    end
-
     def serializer_permission(**args, &data_block)
       serializer_field(:permission, **args, private: true, &data_block)
     end

--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -167,13 +167,7 @@ class ArSerializer::Field
   def self.custom_field(klass, name, includes:, preload:, only:, except:, private:, scoped_access:, order_column:, orderable:, type:, params_type:, &data_block)
     underscore_name = name.underscore
     if preload
-      preloaders = Array(preload).map do |preloader|
-        next preloader if preloader.is_a? Proc
-        unless klass._custom_preloaders.has_key?(preloader)
-          raise ArgumentError, "preloader not found: #{preloader}"
-        end
-        klass._custom_preloaders[preloader]
-      end
+      preloaders = [*preload]
     else
       preloaders = []
       includes ||= underscore_name if klass.respond_to?(:reflect_on_association) && klass.reflect_on_association(underscore_name)

--- a/test/model.rb
+++ b/test/model.rb
@@ -75,11 +75,11 @@ class Comment < ActiveRecord::Base
   serializer_field :stars_count, count_of: :stars
   serializer_field :star
 
-  define_preloader :star_count_loader do |comments|
+  star_count_loader = ->(comments) do
     Star.where(comment_id: comments.map(&:id)).group(:comment_id).count
   end
 
-  serializer_field :stars_count_x5, type: :int, preload: :star_count_loader do |preloaded|
+  serializer_field :stars_count_x5, type: :int, preload: star_count_loader do |preloaded|
     (preloaded[id] || 0) * 5
   end
 


### PR DESCRIPTION
使ってないし要らなさそう
```
define_preloader(:aa){|a|b}
serializer_field :aa, preload: :aa
# ↓
aa = ->(a){b}
serializer_field :aa, preload: aa
```
