### PR TITLE
Feature/underscored parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ class Post < ActiveRecord::Base
   has_many :comments
   serializer_field :comments
 end
-ArSerializer.serialize Post.all, { comments: [:id, params: { order: { key: :id, mode: :desc }, limit: 2 }] }
+ArSerializer.serialize Post.all, { comments: [:id, params: { order_by: :id, direction: :desc, limit: 2 }] }
 
 # context and params
 class Post < ActiveRecord::Base

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ class Post < ActiveRecord::Base
   has_many :comments
   serializer_field :comments
 end
-ArSerializer.serialize Post.all, { comments: [:id, params: { order: { id: :desc }, limit: 2 }] }
+ArSerializer.serialize Post.all, { comments: [:id, params: { order: { key: :id, mode: :desc }, limit: 2 }] }
 
 # context and params
 class Post < ActiveRecord::Base

--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -78,10 +78,11 @@ class ArSerializer::Field
     end
     return :any if any && arguments.empty?
     arguments.map do |key, req|
-      type = key.to_s.match?(/^(.+_)?id|Id$/) ? :int : :any
+      type = key.to_s.match?(/^(.+_)?id$/) ? :int : :any
+      camelcase = key.to_s.camelcase :lower
       name = key.to_s.underscore
       type = [type] if name.singularize.pluralize == name
-      [req ? key : "#{key}?", type]
+      [req ? camelcase : "#{camelcase}?", type]
     end.to_h
   end
 
@@ -223,7 +224,10 @@ class ArSerializer::Field
         modes = %w[asc desc]
         {
           limit?: :int,
-          order?: orderable_keys.map { |key| { key => modes } } +  modes
+          order?: [
+            { key?: orderable_keys.size == 1 ? orderable_keys.first : orderable_keys, mode?: modes },
+            *modes
+          ]
         }
       }
       data_block = lambda do |preloaded, _context, **_params|

--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -183,34 +183,27 @@ class ArSerializer::Field
     )
   end
 
-  def self.parse_order(klass, order, only: nil, except: nil)
+  def self.parse_order(klass, order: nil, order_by: nil, direction: nil, only: nil, except: nil)
+    raise ArSerializer::InvalidQuery, 'invalid order' if order && (order_by || direction)
     primary_key = klass.primary_key.to_sym
-    key, mode = (
+    order_by = order_by&.to_s&.to_sym || primary_key
+    direction = direction&.to_s&.to_sym || :asc
+    if order # deprecated
       case order
       when Hash
-        keys = order.keys.map(&:to_s)
-        if keys.size == 1 && keys != ['mode'] && %w[asc desc].include?(order.values.first.to_s)
-          # deprecated. { key => asc_or_desc }
-          [keys.first.camelize(:lower).to_sym, order.values.first.to_sym]
-        else
-          extra_keys = keys - %w[key mode]
-          raise ArSerializer::InvalidQuery, "invalid order option #{extra_keys}" unless extra_keys.empty?
-          [
-            (order['key'] || order[:key] || primary_key).to_sym,
-            (order['mode'] || order[:mode] || :asc).to_sym
-          ]
-        end
+        raise ArSerializer::InvalidQuery, 'invalid order' unless order.size == 1
+        order_by, direction = order.first.map(&:to_sym)
       when Symbol, 'asc', 'desc'
-        [primary_key, order.to_sym]
-      when NilClass
-        [primary_key, :asc]
+        direction = order.to_sym
+      else
+        raise ArSerializer::InvalidQuery, 'invalid order'
       end
-    )
-    info = klass._serializer_field_info key
-    order_key = (info&.order_column || key).to_s.underscore.to_sym
-    raise ArSerializer::InvalidQuery, "invalid order mode: #{mode.inspect}" unless [:asc, :desc].include? mode
-    raise ArSerializer::InvalidQuery, "unpermitted order key: #{key}" unless key == primary_key || (info&.orderable? && (!only || only.include?(key)) && !except&.include?(key))
-    [order_key, mode]
+    end
+    info = klass._serializer_field_info order_by
+    order_column = (info&.order_column || order_by).to_s.underscore.to_sym
+    raise ArSerializer::InvalidQuery, "invalid order direction: #{direction}" unless [:asc, :desc].include? direction
+    raise ArSerializer::InvalidQuery, "unpermitted order field: #{order_by}" unless order_by == primary_key || (info&.orderable? && (!only || only.include?(order_by)) && !except&.include?(order_by))
+    [order_column, direction]
   end
 
   def self.association_field(klass, name, only:, except:, scoped_access: nil, type:, collection:)
@@ -218,8 +211,8 @@ class ArSerializer::Field
     only = [*only] if only
     except = [*except] if except
     if collection
-      preloader = lambda do |models, _context, limit: nil, order: nil, **_option|
-        preload_association klass, models, underscore_name, limit: limit, order: order, only: only, except: except
+      preloader = lambda do |models, _context, limit: nil, order: nil, order_by: nil, direction: nil, **_option|
+        preload_association klass, models, underscore_name, limit: limit, order: order, order_by: order_by, direction: direction, only: only, except: except
       end
       params_type = -> {
         orderable_keys = klass.reflect_on_association(underscore_name).klass._serializer_orderable_field_keys
@@ -230,10 +223,8 @@ class ArSerializer::Field
         modes = %w[asc desc]
         {
           limit?: :int,
-          order?: [
-            { key?: orderable_keys.size == 1 ? orderable_keys.first : orderable_keys, mode?: modes },
-            *modes
-          ]
+          orderBy?: orderable_keys.size == 1 ? orderable_keys.first : orderable_keys,
+          direction?: modes
         }
       }
       data_block = lambda do |preloaded, _context, **_params|
@@ -250,16 +241,16 @@ class ArSerializer::Field
     new klass, name, preloaders: [preloader], data_block: data_block, only: only, except: except, scoped_access: scoped_access, type: type, params_type: params_type, orderable: false
   end
 
-  def self.preload_association(klass, models, name, limit: nil, order: nil, only: nil, except: nil)
+  def self.preload_association(klass, models, name, limit: nil, order: nil, order_by: nil, direction: nil, only: nil, except: nil)
     limit = limit&.to_i
-    order_key, order_mode = parse_order klass.reflect_on_association(name).klass, order, only: only, except: except
-    return TopNLoader.load_associations klass, models.map(&:id), name, limit: limit, order: { order_key => order_mode } if limit
+    order_column, order_direction = parse_order klass.reflect_on_association(name).klass, order: order, order_by: order_by, direction: direction, only: only, except: except
+    return TopNLoader.load_associations klass, models.map(&:id), name, limit: limit, order: { order_column => order_direction } if limit
     ActiveRecord::Associations::Preloader.new.preload models, name
-    return models.map { |m| [m.id, m.__send__(name)] }.to_h if order.nil?
+    return models.map { |m| [m.id, m.__send__(name)] }.to_h if !order && !order_by && !direction
     models.map do |model|
-      records_nonnils, records_nils = model.__send__(name).partition(&order_key)
-      records = records_nils.sort_by(&:id) + records_nonnils.sort_by { |r| [r[order_key], r.id] }
-      records.reverse! if order_mode == :desc
+      records_nonnils, records_nils = model.__send__(name).partition(&order_column)
+      records = records_nils.sort_by(&:id) + records_nonnils.sort_by { |r| [r[order_column], r.id] }
+      records.reverse! if order_direction == :desc
       [model.id, records]
     end.to_h
   end

--- a/lib/ar_serializer/serializer.rb
+++ b/lib/ar_serializer/serializer.rb
@@ -180,13 +180,13 @@ module ArSerializer::Serializer
     output_for_model
   end
 
-  def self.deep_with_indifferent_access params
+  def self.deep_underscore_keys params
     case params
     when Array
-      params.map { |v| deep_with_indifferent_access v }
+      params.map { |v| deep_underscore_keys v }
     when Hash
-      params.transform_keys(&:to_sym).transform_values! do |v|
-        deep_with_indifferent_access v
+      params.transform_keys { |k| k.to_s.underscore.to_sym }.transform_values! do |v|
+        deep_underscore_keys v
       end
     else
       params
@@ -211,7 +211,7 @@ module ArSerializer::Serializer
           elsif !only_attributes && %i[attributes query].include?(sym_key)
             attributes.concat parse_args(value, only_attributes: true)
           elsif !only_attributes && sym_key == :params
-            params = deep_with_indifferent_access value
+            params = deep_underscore_keys value
           else
             attributes << [sym_key, value == true ? {} : parse_args(value)]
           end

--- a/test/ar_serializer_test.rb
+++ b/test/ar_serializer_test.rb
@@ -261,6 +261,28 @@ class ArSerializerTest < Minitest::Test
     end
   end
 
+  def test_params_underscore
+    klass = Class.new do
+      include ArSerializer::Serializable
+      serializer_field(:p) { |**params| params }
+      serializer_field(:self) { self }
+    end
+    query = {
+      p: { params: { 'a_b' => { c_d: 2, 'eF' => 3 }, gH: { 'i_j' => 4, kL: 5 } } },
+      self: {
+        p: { params: { 'a_b_c' => 1, 'ddEeFf' => 2 } }
+      }
+    }
+    result = ArSerializer.serialize klass.new, query
+    expected = {
+      p: { a_b: { c_d: 2, e_f: 3 }, g_h: { i_j: 4, k_l: 5 } },
+      self: {
+        p: { a_b_c: 1, dd_ee_ff: 2 }
+      }
+    }
+    assert_equal expected, result
+  end
+
   def test_accept_deprecated_ordering
     ns = __method__
     Comment.serializer_field :updatedAt, namespace: ns


### PR DESCRIPTION
#27 
params全部underscoreに...するために `order: { key => asc_or_desc }` を `order: { key: key, mode: asc_or_desc }` に変えた

それだとar_syncが動かなくなるので、直すまでは不完全だけど古いスタイルも受け付ける(ただしunderscoreされたものをcamelize(:lower)するのでお察し)