### PR TITLE
New record serialize bugfix

### DIFF
--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -223,14 +223,14 @@ class ArSerializer::Field
         }
       }
       data_block = lambda do |preloaded, _context, **_params|
-        preloaded ? preloaded[id] || [] : __send__(underscore_name)
+        preloaded ? preloaded[id || self] || [] : __send__(underscore_name)
       end
     else
       preloader = lambda do |models, _context, **_params|
         preload_association klass, models, underscore_name
       end
       data_block = lambda do |preloaded, _context, **_params|
-        preloaded ? preloaded[id] : __send__(underscore_name)
+        preloaded ? preloaded[id || self] : __send__(underscore_name)
       end
     end
     new klass, name, preloaders: [preloader], data_block: data_block, only: only, except: except, scoped_access: scoped_access, type: type, params_type: params_type, orderable: false
@@ -241,12 +241,12 @@ class ArSerializer::Field
     order_key, order_mode = parse_order klass.reflect_on_association(name).klass, order, only: only, except: except
     return TopNLoader.load_associations klass, models.map(&:id), name, limit: limit, order: { order_key => order_mode } if limit
     ActiveRecord::Associations::Preloader.new.preload models, name
-    return models.map { |m| [m.id, m.__send__(name)] }.to_h if order.nil?
+    return models.map { |m| [m.id || m, m.__send__(name)] }.to_h if order.nil?
     models.map do |model|
       records_nonnils, records_nils = model.__send__(name).partition(&order_key)
       records = records_nils.sort_by(&:id) + records_nonnils.sort_by { |r| [r[order_key], r.id] }
       records.reverse! if order_mode == :desc
-      [model.id, records]
+      [model.id || model, records]
     end.to_h
   end
 end

--- a/test/ar_serializer_test.rb
+++ b/test/ar_serializer_test.rb
@@ -397,6 +397,22 @@ class ArSerializerTest < Minitest::Test
     assert(output.any? { |user| user[:favorite_post] && user[:favorite_post][:post][:id] })
   end
 
+  def test_child_of_new_records
+    klass = Class.new do
+      include ArSerializer::Serializable
+      def initialize(user); @user = user; end
+      serializer_field(:user) { @user }
+    end
+    users = User.limit(3)
+    objects = users.map { |u| klass.new u }
+    posts = users.map { |u| Post.new user: u }
+    result1 = ArSerializer.serialize objects, { user: :id }
+    result2 = ArSerializer.serialize posts, { user: :id }
+    expected = users.map { |u| { user: { id: u.id } } }
+    assert_equal expected, result1
+    assert_equal expected, result2
+  end
+
   def test_defaults
     klass = Class.new do
       include ArSerializer::Serializable


### PR DESCRIPTION
`ArSerializer.serialize(users.map{|u|Post.new(user: u)}, { user: :id })`
idをkeyにしてpreloadしているせいで、idがnilだと動かない
レアケースっぽいけどテスト用データ準備するのに使ったらこれが起きて困ったので。