### PR TITLE
Feature/first last

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ class Post < ActiveRecord::Base
   has_many :comments
   serializer_field :comments
 end
-ArSerializer.serialize Post.all, { comments: [:id, params: { order_by: :id, direction: :desc, limit: 2 }] }
+ArSerializer.serialize Post.all, { comments: [:id, params: { order_by: :createdAt, direction: :desc, first: 10 }] }
+ArSerializer.serialize Post.all, { comments: [:id, params: { order_by: :updatedAt, last: 10 }] }
 
 # context and params
 class Post < ActiveRecord::Base

--- a/test/ar_serializer_test.rb
+++ b/test/ar_serializer_test.rb
@@ -69,8 +69,7 @@ class ArSerializerTest < Minitest::Test
   end
 
   def test_serializing_nil
-    result = ArSerializer.serialize nil, :id
-    assert_equal nil, result
+    assert_nil ArSerializer.serialize(nil, :id)
   end
 
   def test_context

--- a/test/ar_serializer_test.rb
+++ b/test/ar_serializer_test.rb
@@ -234,7 +234,7 @@ class ArSerializerTest < Minitest::Test
   def test_association_params
     user = Comment.first.post.user
     expected = { posts: user.posts.map { |p| { comments: p.comments.order(body: :asc).limit(1).map { |c| { id: c.id } } } } }
-    query = { posts: { comments: [:id, params: { limit: 1, order_by: :body }] } }
+    query = { posts: { comments: [:id, params: { first: 1, order_by: :body }] } }
     data = ArSerializer.serialize user, query
     assert_equal expected, data
     data2 = ArSerializer.serialize user, JSON.parse(query.to_json)
@@ -417,16 +417,29 @@ class ArSerializerTest < Minitest::Test
     end
   end
 
+  def test_order_first_last
+    [:asc, :desc].product([:first, :last, :limit]) do |direction, first_last|
+      result = ArSerializer.serialize(Post.all, comments: [:id, params: { order_by: :id, direction: direction, first_last => 2 }])
+      expected = Post.all.map do |post|
+        method = first_last == :limit ? :first : first_last
+        comments = post.comments.order(id: direction).to_a.__send__(method, 2)
+        { comments: comments.map { |c| { id: c.id } } }
+      end
+      binding.irb if expected != result
+      assert_equal expected, result
+    end
+  end
+
   def test_camelized_association
     posts = ArSerializer.serialize Post.all, { Comments: :id, comments: :id }
     assert(posts.all? { |post| post[:comments] == post[:Comments] })
   end
 
   def test_non_array_composite_value
-    output = ArSerializer.serialize User.all, { posts_with_total: [:id, params: { limit: 2 }] }
+    output = ArSerializer.serialize User.all, { first2posts_with_total: :id }
     output_ref = ArSerializer.serialize User.all, { posts: :id }
     result = output.zip(output_ref).all? do |o, oref|
-      posts_with_total = o[:posts_with_total]
+      posts_with_total = o[:first2posts_with_total]
       posts = oref[:posts]
       posts_with_total[:total] == posts.size && posts_with_total[:list] == posts.take(2)
     end

--- a/test/model.rb
+++ b/test/model.rb
@@ -11,11 +11,11 @@ class User < ActiveRecord::Base
   serializer_field :posts_only_body, association: :posts, only: :body
   serializer_field(:favorite_post, type: -> { FavoritePost }) { FavoritePost.new id if id.odd? }
   serializer_field(
-    :posts_with_total,
+    :first2posts_with_total,
     type: -> { { total: :int, list: [Post] } },
-    preload: lambda do |models, _context, **params|
+    preload: lambda do |models, _context|
       [
-        ArSerializer::Field.preload_association(User, models, :posts, **params),
+        ArSerializer::Field.preload_association(User, models, :posts, { order: { id: :asc }, limit: 2 }),
         User.where(id: models.map(&:id)).joins(:posts).group(:id).count
       ]
     end


### PR DESCRIPTION
`{ limit: 10, order: 'desc' }` みたいなのをよく使ってた(使うときにreverse()することが多い)

大体の場合、`{ first: 10 }` や `{ last: 10 }` の方が使いやすそう
limitあるのにoffset指定できないならsqlぽいオプションである意味がない

```
{
  first?: number
  last?: number
  orderBy?: 'id' | 'title' | 'createdAt' | ...
  direction?: 'asc' | 'desc'
}
```