### PR TITLE
preloadでSetを使えるように

### DIFF
--- a/lib/ar_serializer/serializer.rb
+++ b/lib/ar_serializer/serializer.rb
@@ -170,7 +170,7 @@ module ArSerializer::Serializer
           when :data
             data[column_name] = res
           else
-            data[column_name] = fallback&.is_a?(Proc) ? fallback.call : fallback
+            data[column_name] = fallback
           end
         end
       end


### PR DESCRIPTION
```ruby
# こういうのを
User.serializer_field :hasFoo, preload: ->(users) { Foo.where(user_id: users.map(&:id)).pluck(:user_id).to_h{ [_1, true] }, fallback: false

# こう書けると便利。よく使うはず
User.serializer_field :hasFoo, preload: ->(users) { Foo.where(user_id: users.map(&:id)).pluck(:user_id).to_set }
```

fallbackにprocを渡すことなんてないから消した(instance_exec(&fallback)でもなくfallback.callだったし)
