### PR TITLE
default params type for "foo_ids" should be "number[]"

### DIFF
--- a/lib/ar_serializer/field.rb
+++ b/lib/ar_serializer/field.rb
@@ -81,10 +81,18 @@ class ArSerializer::Field
     end
     return :any if any && arguments.empty?
     arguments.map do |key, req|
-      type = key.to_s.match?(/^(.+_)?id$/) ? :int : :any
       camelcase = key.to_s.camelcase :lower
-      name = key.to_s.underscore
-      type = [type] if name.singularize.pluralize == name
+      type = (
+        case key
+        when /^(.+_)?id$/
+          :int
+        when /^(.+_)?ids$/
+          [:int]
+        else
+          name = key.to_s.underscore
+          name.singularize.pluralize == name ? [:any] : :any
+        end
+      )
       [req ? camelcase : "#{camelcase}?", type]
     end.to_h
   end

--- a/test/ar_serializer_test.rb
+++ b/test/ar_serializer_test.rb
@@ -655,6 +655,23 @@ class ArSerializerTest < Minitest::Test
     assert ArSerializer::TypeScript.generate_type_definition(schema)
   end
 
+  def test_params_default_type
+    args_type = ArSerializer::Field.new(Object, :foo, data_block: ->(ctx, id:, ids:, foo_id:,foo_ids:, bar_id: 0, bar_ids: [], apple:, apples:, book: 0, books: []){}).arguments
+    expected = {
+      'id' => :int,
+      'ids' => [:int],
+      'fooId' => :int,
+      'fooIds' => [:int],
+      'barId?' => :int,
+      'barIds?' => [:int],
+      'apple' => :any,
+      'apples' => [:any],
+      'book?' => :any,
+      'books?' => [:any]
+    }
+    assert_equal expected, args_type
+  end
+
   def test_graphql_query_parse
     random_json = lambda do |level|
       chars = %("\\{[]},0a).chars


### PR DESCRIPTION
serializer_field(:name){|ctx, foo_ids:|} の型はfooIds: number[]になってほしいけどany[]になってた