### PR TITLE
raise when typo scoped_access

### DIFF
--- a/lib/ar_serializer/serializer.rb
+++ b/lib/ar_serializer/serializer.rb
@@ -78,7 +78,12 @@ module ArSerializer::Serializer
       end
 
       preloader_values = {}
-      permission_field = klass._serializer_field_info permission == true ? :permission : permission if permission
+      if permission == true
+        permission_field = klass._serializer_field_info :permission
+      elsif permission
+        permission_field = klass._serializer_field_info permission
+        raise ArgumentError, "No permission field #{permission} for #{klass}" unless permission_field
+      end
       if permission_field
         preloadeds = permission_field.preloaders.map do |p|
           preloader_values[[p, nil]] ||= preload.call p, nil


### PR DESCRIPTION
typoしてた時にチェック無しになるのはやばい

デフォルトのpermissionチェックを別のものに上書きする(symbol)かスキップする(false)か選べる
複数選択できたほうがいいかなぁ 上書きじゃなくチェック追加(`[:custom_check, :permission]`)とかしたいかもしれない
あと名前も変えたほうがいいかもしれない わかりにくそう
(確実に権限のあるものを返すから権限チェック省いてくれ、みたいな用途を最初想定してた)
