### PR TITLE
Fix only and except ts type of OptionalType

### DIFF
--- a/lib/ar_serializer/graphql/types.rb
+++ b/lib/ar_serializer/graphql/types.rb
@@ -164,7 +164,7 @@ module ArSerializer::GraphQL
         if type.size == 1
           ListTypeClass.new type.first, only, except
         elsif type.size == 2 && type.last.nil?
-          OptionalTypeClass.new type
+          OptionalTypeClass.new type, only, except
         else
           OrTypeClass.new type, only, except
         end


### PR DESCRIPTION
Fix OptionalType type generating bug.
`only` and `except` option was not applied to generated typescript

```ruby
class Foo
  belongs_to :user, optional: true
  serializer_field :user, only: [:id, :name]
end
```

```ts
export interface TypeFoo {
  user: TypeUser | null
  // ↓
  user: TypeUserOnlyIdName | null
}

export interface TypeFooQueryBase {
  user?: true | TypeUserQuery | { attributes?: TypeUserQuery }
  // ↓
  user?: true | TypeUserOnlyIdNameQuery | { attributes?: TypeUserOnlyIdNameQuery }
}

```