### PR TITLE
Don't generate {} as an empty args type

### DIFF
--- a/lib/ar_serializer/graphql/types.rb
+++ b/lib/ar_serializer/graphql/types.rb
@@ -50,7 +50,7 @@ module ArSerializer::GraphQL
       arg_types = field.arguments.map do |key, type|
         "#{key}: #{TypeClass.from(type).ts_type}"
       end
-      "{ #{arg_types.join '; '} }"
+      arg_types.empty? ? 'Record<string, never>' : "{ #{arg_types.join '; '} }"
     end
 
     serializer_field :name, :args


### PR DESCRIPTION
`{}` is special in TypeScript.
```ts
type TwoParams = { param1: number; param2: number }
type OneParams = { param1: number }
type ZeroParams = Record<string, never> // Not {}
```